### PR TITLE
fix: ensure primary keys are in correct order

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MsBackendSql
 Title: SQL-based Mass Spectrometry Data Backend
-Version: 1.3.3
+Version: 1.3.4
 Authors@R:
     c(person(given = "Johannes", family = "Rainer",
              email = "Johannes.Rainer@eurac.edu",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # MsBackendSql 1.3
 
+## Changes in 1.3.4
+
+- Ensure primary keys from the database are in the correct order for
+  `backendInitialize()`.
+
 ## Changes in 1.3.3
 
 - Import method generics from `ProtGenerics`.

--- a/R/MsBackendSql.R
+++ b/R/MsBackendSql.R
@@ -484,7 +484,8 @@ setMethod("backendInitialize", "MsBackendSql",
     if (length(msg)) stop(msg)
     object@dbcon <- dbcon
     object@spectraIds <- dbGetQuery(
-        dbcon, "select spectrum_id_ from msms_spectrum")[, 1L]
+        dbcon, paste0("select spectrum_id_ from msms_spectrum ",
+                      "order by spectrum_id_"))[, 1L]
     object@.tables <- list(
         msms_spectrum = colnames(
             dbGetQuery(dbcon, "select * from msms_spectrum limit 0")))


### PR DESCRIPTION
- Ensure the primary keys for spectra are extracted in the correct order in `backendInitialize()`.