### PR TITLE
Ensure peaks are ordered correctly with longForm() and duckdb

### DIFF
--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -54,8 +54,8 @@ jobs:
       matrix:
         config:
           - { os: ubuntu-latest, r: 'devel', bioc: 'devel', cont: "bioconductor/bioconductor_docker:devel", rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest" }
-          - { os: macOS-latest, r: 'latest', bioc: 'devel'}
-          - { os: windows-latest, r: 'latest', bioc: 'devel'}
+          - { os: macOS-latest, r: 'devel', bioc: 'devel'}
+          - { os: windows-latest, r: 'devel', bioc: 'devel'}
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MsBackendSql
 Title: SQL-based Mass Spectrometry Data Backend
-Version: 1.10.0
+Version: 1.11.0
 Authors@R:
     c(person(given = "Johannes", family = "Rainer",
              email = "Johannes.Rainer@eurac.edu",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MsBackendSql
 Title: SQL-based Mass Spectrometry Data Backend
-Version: 1.11.0
+Version: 1.11.1
 Authors@R:
     c(person(given = "Johannes", family = "Rainer",
              email = "Johannes.Rainer@eurac.edu",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MsBackendSql
 Title: SQL-based Mass Spectrometry Data Backend
-Version: 1.9.4
+Version: 1.10.0
 Authors@R:
     c(person(given = "Johannes", family = "Rainer",
              email = "Johannes.Rainer@eurac.edu",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,12 @@
-# MsBackendSql 1.9
+# MsBackendSql 1.11.1
 
 - For storage mode of peaks data in long form (i.e., one row per peak), create a
   incremental (unique) *peak_id_* database column if the database requires that
   (e.g. for DuckDb).
+- `longForm()` on a database requiring *peak_id_* (e.g. DuckDb) order results
+  based on the *peak_id_* column.
+
+# MsBackendSql 1.9
 
 ## Changes in 1.9.4
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # MsBackendSql 1.9
 
+- For storage mode of peaks data in long form (i.e., one row per peak), create a
+  incremental (unique) *peak_id_* database column if the database requires that
+  (e.g. for DuckDb).
+
 ## Changes in 1.9.4
 
 - Add additional unit tests to check results are similar to the reference

--- a/R/MsBackendSql-functions.R
+++ b/R/MsBackendSql-functions.R
@@ -81,7 +81,6 @@ MsBackendSql <- function() {
     extractCOLS(res, columns)
 }
 
-
 #' @param x backend
 #'
 #' @param columns `character` with the column(s) to retrieve.

--- a/R/MsBackendSql.R
+++ b/R/MsBackendSql.R
@@ -545,6 +545,9 @@ setMethod("backendInitialize", "MsBackendSql",
     } else {
         object@.tables[["msms_spectrum_peak"]] <- colnames(
             dbGetQuery(dbcon, "select * from msms_spectrum_peak limit 0"))
+        if (.db_requires_peak_id(dbcon) && !.has_peak_id(object))
+            stop("The type of SQL database respectively connection ('",
+                 class(dbcon)[1L], "') requires unique peak identifiers!")
     }
     ## Initialize cached backend
     object <- callNextMethod(

--- a/tests/testthat/test_MsBackendSql.R
+++ b/tests/testthat/test_MsBackendSql.R
@@ -32,6 +32,15 @@ test_that("backendInitialize works", {
       , "Replacing")
     expect_true(length(be2) == 0L)
     expect_equal(spectraVariables(be2), spectraVariables(be))
+
+    with_mocked_bindings(
+        ".has_peak_id" = function(x) FALSE,
+        ".db_requires_peak_id" = function(x) TRUE,
+        code = expect_error(backendInitialize(
+            MsBackendSql(), dbcon = dbConnect(SQLite(), tempfile()),
+            data = spectraData(be), peaksStorageMode = "long", blob = FALSE),
+            "The type of SQL database")
+    )
 })
 
 test_that("dataStorage works", {
@@ -752,4 +761,13 @@ test_that("MsBackendSql extracted data matches reference implementation", {
     res <- longForm(mm8_be_blob2, c("rtime"))
     ref <- longForm(ref_be, "rtime")
     expect_equal(res, ref)
+})
+
+test_that("long-form database is created with peak_id_ for duckdb", {
+    ## mock .is_duckdb to return TRUE.
+    ## Using `setBackend()` from another backend: .create_from_spectra_data
+    ## should add that column.
+
+    ## Creating from mzML files: .insert_backend should do that - and in fact
+    ## also create proper, running values.
 })

--- a/tests/testthat/test_MsBackendSql.R
+++ b/tests/testthat/test_MsBackendSql.R
@@ -33,6 +33,7 @@ test_that("backendInitialize works", {
     expect_true(length(be2) == 0L)
     expect_equal(spectraVariables(be2), spectraVariables(be))
 
+    ## Error if peak_id_ is missing for databases require that column
     with_mocked_bindings(
         ".has_peak_id" = function(x) FALSE,
         ".db_requires_peak_id" = function(x) TRUE,
@@ -763,11 +764,72 @@ test_that("MsBackendSql extracted data matches reference implementation", {
     expect_equal(res, ref)
 })
 
-test_that("long-form database is created with peak_id_ for duckdb", {
-    ## mock .is_duckdb to return TRUE.
-    ## Using `setBackend()` from another backend: .create_from_spectra_data
-    ## should add that column.
+test_that("long-form database with peak_id_ mocking duckdb", {
+    tf <- tempfile()
+    tmp <- dbConnect(SQLite(), tf)
+    be_l <- with_mocked_bindings(
+        ".db_requires_peak_id" = function(x) TRUE,
+        code = setBackend(mm8_sps, MsBackendSql(), dbcon = tmp,
+                          peaksStorageMode = "long", blob = FALSE)
+    )
+    res <- dbGetQuery(tmp, "select * from msms_spectrum_peak limit 3")
+    expect_equal(colnames(res), c("mz", "intensity", "spectrum_id_","peak_id_"))
+    ## no join query involved
+    a <- spectraData(be_l, columns = c("rtime", "mz", "intensity"))
+    b <- with_mocked_bindings(
+        ".db_requires_peak_id" = function(x) TRUE,
+        code = spectraData(be_l, columns = c("rtime", "mz", "intensity"))
+    )
+    expect_equal(a, b)
+    ## uses join query; mocking need for ordering by peak_id_
+    a <- longForm(be_l, columns = c("rtime", "mz", "intensity"))
+    b <- with_mocked_bindings(
+        ".db_requires_peak_id" = function(x) TRUE,
+        code = longForm(be_l, columns = c("rtime", "mz", "intensity"))
+    )
+    expect_equal(a, b)
+    dbDisconnect(tmp)
+    unlink(tf)
+
+    tf <- tempfile()
+    tmp <- dbConnect(SQLite(), tf)
+    be_l <- with_mocked_bindings(
+        ".db_requires_peak_id" = function(x) TRUE,
+        code = backendInitialize(
+            MsBackendSql(), data = spectraData(mm8_be_long), dbcon = tmp,
+            peaksStorageMode = "long", blob = FALSE)
+    )
+    res <- dbGetQuery(tmp, "select * from msms_spectrum_peak limit 3")
+    expect_equal(colnames(res), c("mz", "intensity", "spectrum_id_","peak_id_"))
+    ## uses join query; mocking need for ordering by peak_id_
+    a <- longForm(be_l, columns = c("rtime", "mz", "intensity"))
+    b <- with_mocked_bindings(
+        ".db_requires_peak_id" = function(x) TRUE,
+        code = longForm(be_l, columns = c("rtime", "mz", "intensity"))
+    )
+    expect_equal(a, b)
+    dbDisconnect(tmp)
+    unlink(tf)
 
     ## Creating from mzML files: .insert_backend should do that - and in fact
     ## also create proper, running values.
+    tf <- tempfile()
+    tmp <- dbConnect(SQLite(), tf)
+    with_mocked_bindings(
+        ".db_requires_peak_id" = function(x) TRUE,
+        code = createMsBackendSqlDatabase(
+            dbcon = tmp, mm8_file, peaksStorageMode = "long", blob = FALSE)
+      , .package = "MsBackendSql")
+    be_l <- backendInitialize(MsBackendSql(), tmp)
+    res <- dbGetQuery(tmp, "select * from msms_spectrum_peak limit 3")
+    expect_equal(colnames(res), c("mz", "intensity", "spectrum_id_","peak_id_"))
+    ## uses join query; mocking need for ordering by peak_id_
+    a <- longForm(be_l, columns = c("rtime", "mz", "intensity"))
+    b <- with_mocked_bindings(
+        ".db_requires_peak_id" = function(x) TRUE,
+        code = longForm(be_l, columns = c("rtime", "mz", "intensity"))
+    )
+    expect_equal(a, b)
+    dbDisconnect(tmp)
+    unlink(tf)
 })


### PR DESCRIPTION
This PR adds fixes that ensure peaks are ordered (by their original order) correctly in the result of `longForm()` on a `MsBackendSql` using a *duckdb* as SQL backend (issue #31).