### PR TITLE
refactor: tiny performance improvements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MsBackendSql
 Title: SQL-based Mass Spectrometry Data Backend
-Version: 1.11.1
+Version: 1.11.2
 Authors@R:
     c(person(given = "Johannes", family = "Rainer",
              email = "Johannes.Rainer@eurac.edu",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,13 @@
-# MsBackendSql 1.11.1
+# MsBackendSql 1.11
+
+## Changes in 1.11.2
+
+- Small update to the internal function to extract the spectra data: avoid
+  `fmatch()` call if not needed.
+- Pass sorted spectra IDs to the SQL query, which can result in a tiny
+  performance gain.
+
+## Changes in 1.11.1
 
 - For storage mode of peaks data in long form (i.e., one row per peak), create a
   incremental (unique) *peak_id_* database column if the database requires that

--- a/R/MsBackendSql-functions.R
+++ b/R/MsBackendSql-functions.R
@@ -98,7 +98,7 @@ MsBackendSql <- function() {
             x@dbcon,
             stri_c("select spectrum_id_,", stri_c(columns, collapse = ","),
                    " from msms_spectrum_peak where spectrum_id_ in (",
-                   stri_c(unique(x@spectraIds), collapse = ","), ")"))
+                   stri_c(base::sort(x@spectraIds), collapse = ","), ")"))
         sid <- as.factor(p$spectrum_id)
         if (drop && length(columns == 1L)) {
             p <- split(p[, columns], sid)[as.character(x@spectraIds)]
@@ -131,7 +131,7 @@ MsBackendSql <- function() {
             x@dbcon,
             stri_c("select spectrum_id_,", stri_c(columns, collapse = ","),
                    " from msms_spectrum_peak_blob where spectrum_id_ in (",
-                   stri_c(unique(x@spectraIds), collapse = ","), ")"))
+                   stri_c(base::sort(x@spectraIds), collapse = ","), ")"))
         sid <- p$spectrum_id_
         attributes(sid) <- NULL
         if (!length(sid)) return(list())
@@ -147,7 +147,7 @@ MsBackendSql <- function() {
         if (identical(base::unname(x@spectraIds), sid))
             res
         else
-            res[fmatch(x@spectraIds, p$spectrum_id_)]
+            res[fmatch(x@spectraIds, sid)]
     } else list()
 }
 
@@ -164,7 +164,7 @@ MsBackendSql <- function() {
             x@dbcon,
             stri_c("select spectrum_id_, peaks",
                    " from msms_spectrum_peak_blob2 where spectrum_id_ in (",
-                   stri_c(unique(x@spectraIds), collapse = ","), ")"))
+                   stri_c(base::sort(x@spectraIds), collapse = ","), ")"))
         sid <- p$spectrum_id_
         attributes(sid) <- NULL
         if (!length(sid)) return(list())
@@ -180,7 +180,7 @@ MsBackendSql <- function() {
         if (identical(base::unname(x@spectraIds), sid))
             res
         else
-            res[fmatch(x@spectraIds, p$spectrum_id_)]
+            res[fmatch(x@spectraIds, sid)]
     } else list()
 }
 
@@ -193,10 +193,15 @@ MsBackendSql <- function() {
         x@dbcon,
         stri_c("select ", stri_c(sql_columns, collapse = ","), " from ",
                "msms_spectrum where spectrum_id_ in (",
-               stri_c(unique(x@spectraIds), collapse = ", ") , ")"))
-    idx <- fmatch(x@spectraIds, res$spectrum_id_)
-    if (is.unsorted(idx, strictly = TRUE) || anyNA(idx))
-        res <- res[idx[!is.na(idx)], , drop = FALSE]
+               stri_c(base::sort(x@spectraIds), collapse = ",") , ")"))
+    ## idx <- fmatch(x@spectraIds, res$spectrum_id_)
+    ## if (is.unsorted(idx, strictly = TRUE) || anyNA(idx)) {
+    ##     res <- res[idx[!is.na(idx)], , drop = FALSE]
+    ## }
+    sid <- res$spectrum_id_
+    attributes(sid) <- NULL
+    if (!identical(base::unname(x@spectraIds), sid))
+        res <- res[fmatch(x@spectraIds, sid), , drop = FALSE]
     rownames(res) <- NULL
     res[, orig_columns, drop = FALSE]
 }
@@ -245,7 +250,7 @@ MsBackendSql <- function() {
         what <- "msms_spectrum_peak.spectrum_id_"
     }
     qry <- stri_c(qry, " where ", what, " in (",
-                  stri_c(unique(x@spectraIds), collapse = ", ") , ")", ordr)
+                  stri_c(base::sort(x@spectraIds), collapse = ",") , ")", ordr)
     res <- dbGetQuery(x@dbcon, qry)
     if (anyDuplicated(x@spectraIds)) { # use findMatches() only when needed
         m <- findMatches(x@spectraIds, res$spectrum_id_)

--- a/vignettes/MsBackendSql.Rmd
+++ b/vignettes/MsBackendSql.Rmd
@@ -245,13 +245,15 @@ the MS data. The most intuitive way to store MS data would be the *long* format
 mass peak as a single row. While this would allow to filter e.g. the peaks data
 by *m/z* and/or intensity values already on the SQL level, it significantly
 increases the size of the database. This is in particular true for
-*SQLite*-based databases. The default storage mode (`peaksStorageMode
-= "blob2"`) stores the complete peaks matrix (i.e. the two-column numerical
-matrix of *m/z* and intensity values) of spectrum as one entity to the
-database. This entry is stored as a binary data type (BLOB) in the database
-table (one row per spectrum). This reduces the size of the database and  well
-as the time to extract (peaks) data. On the downside, such databases will only
-be readable and usable with *MsBackendSql*.
+*SQLite*-based databases. The default storage mode (`peaksStorageMode =
+"blob2"`) stores the complete peaks matrix (i.e. the two-column numerical matrix
+of *m/z* and intensity values) of spectrum as one entity to the database. This
+entry is stored as a binary data type (BLOB) in the database table (one row per
+spectrum). This has a positive impact on the performance of the database to
+extract peak data (which is much faster than from databases with the *long*
+peaks storage mode). In addition, also the size (disk space) of such databases
+are smaller. On the downside, these databases will only be readable and usable
+with *MsBackendSql* or R-based tools.
 
 For *MsBackendSql* in the *long* peaks storage mode it is suggested to use
 *duckdb* as database backend.


### PR DESCRIPTION
- Pass sorted spectra IDs to the SQL queries.
- Avoid matching and re-ordering of `spectraData()` rows if not required.